### PR TITLE
Add repository and domain modules for ARX archive management

### DIFF
--- a/arx-core/src/codec/mod.rs
+++ b/arx-core/src/codec/mod.rs
@@ -16,3 +16,11 @@ pub trait Compressor: Send + Sync {
 
 pub mod store;
 pub mod zstdc;
+
+pub fn get_decoder_u8(codec: u8) -> Result<&'static dyn Compressor> {
+    match codec {
+        val if val == CodecId::Store as u8 => Ok(&store::Store),
+        val if val == CodecId::Zstd as u8 => Ok(&zstdc::ZstdCompressor),
+        _ => Err(std::io::Error::new(std::io::ErrorKind::Other, "unknown codec id").into()),
+    }
+}

--- a/arx-core/src/domain.rs
+++ b/arx-core/src/domain.rs
@@ -1,0 +1,20 @@
+// arx_core/src/domain.rs
+#[derive(Clone, Debug)]
+pub struct FileRow {
+    pub path: String,
+    pub u_size: u64,
+    pub chunks: usize,
+    pub encrypted: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct ChunkRow {
+    pub ordinal: u64,
+    pub id: u64,
+    pub codec: u8,
+    pub file_off: u64,
+    pub u_len: u64,
+    pub c_len: u64,
+    pub data_off: u64,
+    pub pct_end: f32,
+}

--- a/arx-core/src/lib.rs
+++ b/arx-core/src/lib.rs
@@ -43,7 +43,9 @@ pub mod pack {
 
 pub mod read {
     pub mod extract;
+    pub mod opened;
     pub mod reader;
+    pub mod stream;
 }
 
 pub mod list;
@@ -55,6 +57,12 @@ pub use pack::writer::{PackOptions, pack};
 pub use read::extract::{ExtractOptions, extract};
 
 pub use list::{ListOptions, list};
+
+pub mod repo;
+pub mod repo_factory;
+pub mod repo_fs;
+
+pub mod domain;
 
 pub use container::chunktab::ChunkEntry;
 pub use container::manifest::{DirEntry, FileEntry, Manifest};

--- a/arx-core/src/read/opened.rs
+++ b/arx-core/src/read/opened.rs
@@ -1,0 +1,187 @@
+use crate::container::chunktab::{ChunkEntry, ENTRY_SIZE, read_table_from_slice};
+use crate::container::manifest::Manifest;
+use crate::container::superblock::{FLAG_ENCRYPTED, HEADER_LEN, Superblock};
+use crate::container::tail::{TAIL_LEN, TAIL_MAGIC};
+use crate::crypto::aead::{AeadKey, Region, derive_nonce};
+use crate::error::Result;
+use std::sync::Mutex;
+use std::{
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+    path::Path,
+    sync::Arc,
+};
+
+#[derive(Clone, Debug)]
+pub struct FileEntry {
+    pub path: String,
+    pub u_size: u64,
+    pub chunks: Vec<u32>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ChunkView {
+    pub ordinal: u64,
+    pub id: u64, // index into table
+    pub codec: u8,
+    pub file_off: u64,
+    pub u_len: u64,
+    pub c_len: u64,
+    pub data_off: u64,
+    pub pct_end: f32,
+}
+
+pub struct Opened {
+    pub f: Arc<Mutex<File>>,
+    pub sb: Superblock,
+    pub manifest: Manifest,
+    pub table: Vec<ChunkEntry>,
+    pub aead: Option<(AeadKey, [u8; 32])>,
+    pub file_end_for_data: u64,
+}
+
+impl Opened {
+    pub fn open(path: &Path, aead_key: Option<[u8; 32]>, key_salt: [u8; 32]) -> Result<Self> {
+        let mut f = File::open(path)?;
+        let file_len = f.metadata()?.len();
+
+        // superblock
+        let sb = Superblock::read_from(&mut f)?;
+        let enc_enabled = (sb.flags & FLAG_ENCRYPTED) != 0;
+
+        // tail (optional)
+        let mut file_end_for_data = file_len;
+        if file_len >= TAIL_LEN {
+            f.seek(SeekFrom::End(-(TAIL_LEN as i64)))?;
+            let mut magic = [0u8; 8];
+            if f.read_exact(&mut magic).is_ok() && magic == TAIL_MAGIC {
+                file_end_for_data = file_len - TAIL_LEN;
+            }
+        }
+
+        // manifest
+        f.seek(SeekFrom::Start(HEADER_LEN))?;
+        let mut mbytes = vec![0u8; sb.manifest_len as usize];
+        f.read_exact(&mut mbytes)?;
+        let manifest_bytes = if enc_enabled {
+            let key = aead_key.ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "encrypted; --key/--key-salt required",
+                )
+            })?;
+            let nonce = derive_nonce(&key_salt, Region::Manifest, 0);
+            crate::crypto::aead::open_whole(&AeadKey(key), &nonce, b"manifest", &mbytes)
+        } else {
+            mbytes
+        };
+        let manifest: Manifest = ciborium::de::from_reader(&manifest_bytes[..])
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+        // chunk table
+        let table_ct_len = sb.data_off - sb.chunk_table_off;
+        f.seek(SeekFrom::Start(sb.chunk_table_off))?;
+        let mut tbytes = vec![0u8; table_ct_len as usize];
+        f.read_exact(&mut tbytes)?;
+        let raw_table = if enc_enabled {
+            let key = aead_key.unwrap();
+            let nonce = derive_nonce(&key_salt, Region::ChunkTable, 0);
+            crate::crypto::aead::open_whole(&AeadKey(key), &nonce, b"chunktab", &tbytes)
+        } else {
+            tbytes
+        };
+        let expected_pt_len = sb.chunk_count as usize * ENTRY_SIZE;
+        if raw_table.len() != expected_pt_len {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                format!(
+                    "chunk table size mismatch: got {} expected {}",
+                    raw_table.len(),
+                    expected_pt_len
+                ),
+            )
+            .into());
+        }
+        let table = read_table_from_slice(&mut &raw_table[..], sb.chunk_count)?;
+
+        // bounds
+        for (i, ce) in table.iter().enumerate() {
+            if ce.data_off < sb.data_off
+                || ce.data_off.saturating_add(ce.c_size) > file_end_for_data
+            {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("chunk[{}] out of bounds", i),
+                )
+                .into());
+            }
+        }
+
+        Ok(Self {
+            f: Arc::new(Mutex::new(f)),
+            sb,
+            manifest,
+            table,
+            aead: if enc_enabled {
+                Some((AeadKey(aead_key.unwrap()), key_salt))
+            } else {
+                None
+            },
+            file_end_for_data,
+        })
+    }
+
+    pub fn list_entries(&self) -> impl Iterator<Item = FileEntry> + '_ {
+        self.manifest.files.iter().map(|fe| FileEntry {
+            path: fe.path.clone(),
+            u_size: fe.u_size,
+            chunks: fe.chunk_refs.iter().map(|r| r.id as u32).collect(),
+        })
+    }
+
+    pub fn chunk_map_for(&self, path: &str) -> Result<Vec<ChunkView>> {
+        let fe = self
+            .manifest
+            .files
+            .iter()
+            .find(|x| x.path == path)
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("no such file: {}", path),
+                )
+            })?;
+        let mut acc = 0u64;
+        let mut out = Vec::with_capacity(fe.chunk_refs.len());
+        for (ord, cref) in fe.chunk_refs.iter().enumerate() {
+            let ce = &self.table[cref.id as usize];
+            let end = acc + ce.u_size as u64;
+            let pct_end = (end as f64 / fe.u_size.max(1) as f64) as f32;
+            out.push(ChunkView {
+                ordinal: ord as u64,
+                id: cref.id,
+                codec: ce.codec,
+                file_off: acc,
+                u_len: ce.u_size,
+                c_len: ce.c_size,
+                data_off: ce.data_off,
+                pct_end,
+            });
+            acc = end;
+        }
+        Ok(out)
+    }
+
+    // Readers implemented in read/stream.rs:
+    pub fn open_reader(&self, path: &str) -> Result<crate::read::stream::FileReader<'_>> {
+        crate::read::stream::FileReader::new(self, path)
+    }
+    pub fn open_range(
+        &self,
+        path: &str,
+        start: u64,
+        len: u64,
+    ) -> Result<crate::read::stream::RangeReader<'_>> {
+        crate::read::stream::RangeReader::new(self, path, start, len)
+    }
+}

--- a/arx-core/src/read/stream.rs
+++ b/arx-core/src/read/stream.rs
@@ -1,0 +1,108 @@
+use super::opened::Opened;
+use crate::crypto::aead::{Region, derive_nonce};
+use crate::error::Result;
+use std::io::{Cursor, Read, Seek, SeekFrom};
+
+pub struct FileReader<'a> {
+    arx: &'a Opened,
+    chunk_ids: Vec<u32>,
+    cur: usize,
+    cur_buf: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> FileReader<'a> {
+    pub fn new(arx: &'a Opened, path: &str) -> Result<Self> {
+        let map = arx.chunk_map_for(path)?;
+        Ok(Self {
+            arx,
+            chunk_ids: map.into_iter().map(|v| v.id as u32).collect(),
+            cur: 0,
+            cur_buf: None,
+        })
+    }
+
+    fn load_next(&mut self) -> std::io::Result<bool> {
+        if self.cur >= self.chunk_ids.len() {
+            return Ok(false);
+        }
+        let idx = self.chunk_ids[self.cur] as usize;
+        let ce = &self.arx.table[idx];
+
+        // read ciphertext
+        let mut f = self
+            .arx
+            .f
+            .lock()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+        f.seek(SeekFrom::Start(ce.data_off))?;
+        let mut ct = vec![0u8; ce.c_size as usize];
+        f.read_exact(&mut ct)?;
+        drop(f);
+
+        // AEAD open (if enabled) — uses Data region with chunk index as counter
+        let pt = if let Some((ref key, salt)) = self.arx.aead {
+            let nonce = derive_nonce(&salt, Region::ChunkData, idx as u64);
+            crate::crypto::aead::open_whole(key, &nonce, b"chunk", &ct)
+        } else {
+            ct
+        };
+
+        // decompress (Store/Zstd)
+        let mut plain = vec![0u8; ce.u_size as usize];
+        let n = crate::codec::get_decoder_u8(ce.codec as u8)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?
+            .decompress(&mut pt.as_slice(), &mut plain.as_mut_slice())
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+        plain.truncate(n as usize);
+
+        self.cur += 1;
+        self.cur_buf = Some(Cursor::new(plain));
+        Ok(true)
+    }
+}
+
+impl<'a> Read for FileReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        loop {
+            if let Some(ref mut cur) = self.cur_buf {
+                let n = cur.read(buf)?;
+                if n > 0 {
+                    return Ok(n);
+                }
+                self.cur_buf = None;
+            }
+            if !self.load_next()? {
+                return Ok(0);
+            }
+        }
+    }
+}
+
+pub struct RangeReader<'a> {
+    inner: FileReader<'a>,
+    remain: u64,
+}
+
+impl<'a> RangeReader<'a> {
+    pub fn new(arx: &'a Opened, path: &str, start: u64, len: u64) -> Result<Self> {
+        let mut fr = FileReader::new(arx, path)?;
+        // advance by consuming `start` bytes (bounded: per-chunk buffer only)
+        std::io::copy(&mut (&mut fr).take(start), &mut std::io::sink())?;
+        Ok(Self {
+            inner: fr,
+            remain: len,
+        })
+    }
+}
+
+impl<'a> Read for RangeReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.remain == 0 {
+            return Ok(0);
+        }
+        let cap = std::cmp::min(self.remain, buf.len() as u64) as usize;
+        let n = (&mut self.inner).read(&mut buf[..cap])?;
+        self.remain -= n as u64;
+        Ok(n)
+    }
+}

--- a/arx-core/src/repo.rs
+++ b/arx-core/src/repo.rs
@@ -1,0 +1,21 @@
+// arx_core/src/repo.rs
+use crate::domain::{ChunkRow, FileRow};
+use crate::error::Result;
+use std::io::Read;
+
+#[derive(Clone, Debug)]
+pub struct OpenParams {
+    pub archive_path: std::path::PathBuf,
+    pub aead_key: Option<[u8; 32]>,
+    pub key_salt: [u8; 32],
+}
+
+pub trait ArchiveRepo: Send + Sync {
+    fn list_files(&self) -> Result<Vec<FileRow>>;
+
+    fn chunk_map(&self, path: &str) -> Result<Vec<ChunkRow>>;
+
+    fn open_reader(&self, path: &str) -> Result<Box<dyn Read + Send + '_>>;
+
+    fn open_range(&self, path: &str, start: u64, len: u64) -> Result<Box<dyn Read + Send + '_>>;
+}

--- a/arx-core/src/repo_factory.rs
+++ b/arx-core/src/repo_factory.rs
@@ -1,0 +1,13 @@
+use crate::error::Result;
+use crate::repo::{ArchiveRepo, OpenParams};
+use crate::repo_fs::FsArchiveRepo;
+
+pub enum Backend {
+    Fs,
+}
+
+pub fn open_repo(backend: Backend, p: OpenParams) -> Result<Box<dyn ArchiveRepo>> {
+    match backend {
+        Backend::Fs => Ok(Box::new(FsArchiveRepo::new(p)?)),
+    }
+}

--- a/arx-core/src/repo_fs.rs
+++ b/arx-core/src/repo_fs.rs
@@ -1,0 +1,64 @@
+use std::io::Read;
+use std::sync::Arc;
+
+use crate::domain::{ChunkRow, FileRow};
+use crate::error::Result;
+use crate::read::opened::Opened;
+use crate::repo::{ArchiveRepo, OpenParams};
+
+pub struct FsArchiveRepo {
+    opened: Arc<Opened>,
+}
+
+impl FsArchiveRepo {
+    pub fn new(params: OpenParams) -> Result<Self> {
+        let opened = Opened::open(&params.archive_path, params.aead_key, params.key_salt)?;
+        Ok(Self {
+            opened: Arc::new(opened),
+        })
+    }
+}
+
+impl ArchiveRepo for FsArchiveRepo {
+    fn list_files(&self) -> Result<Vec<FileRow>> {
+        let enc = self.opened.aead.is_some();
+        let rows = self
+            .opened
+            .list_entries()
+            .map(|e| FileRow {
+                path: e.path,
+                u_size: e.u_size,
+                chunks: e.chunks.len(),
+                encrypted: enc,
+            })
+            .collect();
+        Ok(rows)
+    }
+
+    fn chunk_map(&self, path: &str) -> Result<Vec<ChunkRow>> {
+        let v = self.opened.chunk_map_for(path)?;
+        Ok(v.into_iter()
+            .map(|r| ChunkRow {
+                ordinal: r.ordinal,
+                id: r.id,
+                codec: r.codec,
+                file_off: r.file_off,
+                u_len: r.u_len,
+                c_len: r.c_len,
+                data_off: r.data_off,
+                pct_end: r.pct_end,
+            })
+            .collect())
+    }
+
+    fn open_reader(&self, path: &str) -> Result<Box<dyn Read + Send + '_>> {
+        let r = self.opened.open_reader(path)?;
+        // Box to erase type; keep it Send
+        Ok(Box::new(r))
+    }
+
+    fn open_range(&self, path: &str, start: u64, len: u64) -> Result<Box<dyn Read + Send + '_>> {
+        let r = self.opened.open_range(path, start, len)?;
+        Ok(Box::new(r))
+    }
+}

--- a/arxdev/src/main.rs
+++ b/arxdev/src/main.rs
@@ -2,7 +2,13 @@ use arx_core::crypto::hex::parse_hex_array;
 use arx_core::error::Result;
 use arx_core::read::extract::verify;
 use arx_core::{ExtractOptions, ListOptions, PackOptions, extract, list, pack};
+
+use arx_core::repo::{ArchiveRepo, OpenParams};
+use arx_core::repo_factory::{Backend, open_repo};
+
 use clap::{Parser, Subcommand};
+use std::io::Read;
+use std::io::Write;
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -10,6 +16,46 @@ use std::path::PathBuf;
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+}
+
+#[derive(Subcommand)]
+enum ChunkCommands {
+    /// Print chunk map for one file
+    Chunks {
+        archive: PathBuf,
+        path: String,
+        #[arg(long = "key")]
+        key_hex: Option<String>,
+        #[arg(long = "key-salt")]
+        key_salt_hex: Option<String>,
+    },
+    /// Stream a file (or range) to stdout
+    Cat {
+        archive: PathBuf,
+        path: String,
+        #[arg(long, default_value_t = 0)]
+        start: u64,
+        #[arg(long)]
+        len: Option<u64>,
+        #[arg(long = "key")]
+        key_hex: Option<String>,
+        #[arg(long = "key-salt")]
+        key_salt_hex: Option<String>,
+    },
+    /// Download one file (or range) to an output path
+    Get {
+        archive: PathBuf,
+        path: String,
+        out: PathBuf,
+        #[arg(long, default_value_t = 0)]
+        start: u64,
+        #[arg(long)]
+        len: Option<u64>,
+        #[arg(long = "key")]
+        key_hex: Option<String>,
+        #[arg(long = "key-salt")]
+        key_salt_hex: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -73,6 +119,29 @@ enum Commands {
         #[arg(long = "key-salt")]
         key_salt_hex: Option<String>,
     },
+
+    #[command(subcommand)]
+    /// Inspect a file’s chunk map
+    Chunk(ChunkCommands),
+}
+
+fn repo_from_args(
+    archive: PathBuf,
+    key_hex: Option<String>,
+    key_salt_hex: Option<String>,
+) -> Result<Box<dyn ArchiveRepo>> {
+    let aead_key = key_hex.map(|h| parse_hex_array::<32>(&h)).transpose()?;
+    let key_salt = key_salt_hex
+        .map(|h| parse_hex_array::<32>(&h))
+        .transpose()?
+        .unwrap_or([0u8; 32]);
+
+    let params = OpenParams {
+        archive_path: archive,
+        aead_key,
+        key_salt,
+    };
+    open_repo(Backend::Fs, params)
 }
 
 fn main() -> Result<()> {
@@ -171,6 +240,74 @@ fn main() -> Result<()> {
             verify(&archive, opts.as_ref())?;
             eprintln!("verify: OK");
         }
+
+        Commands::Chunk(chunk_cmd) => match chunk_cmd {
+            ChunkCommands::Chunks {
+                archive,
+                path,
+                key_hex,
+                key_salt_hex,
+            } => {
+                let repo = repo_from_args(archive, key_hex, key_salt_hex)?;
+                let rows = repo.chunk_map(&path)?;
+                for r in rows {
+                    println!(
+                        "#{:<5} id={:<6} codec={} u={} c={} off={}",
+                        r.ordinal, r.id, r.codec, r.u_len, r.c_len, r.data_off
+                    );
+                }
+            }
+            ChunkCommands::Cat {
+                archive,
+                path,
+                start,
+                len,
+                key_hex,
+                key_salt_hex,
+            } => {
+                let repo = repo_from_args(archive, key_hex, key_salt_hex)?;
+                let mut reader: Box<dyn Read + Send> = if let Some(l) = len {
+                    repo.open_range(&path, start, l)?
+                } else {
+                    // default to a huge len to stream to EOF (keeps interface simple)
+                    repo.open_range(&path, start, u64::MAX / 4)?
+                };
+                let mut out = std::io::stdout().lock();
+                let mut buf = [0u8; 64 * 1024];
+                loop {
+                    let n = reader.read(&mut buf)?;
+                    if n == 0 {
+                        break;
+                    }
+                    out.write_all(&buf[..n])?;
+                }
+            }
+            ChunkCommands::Get {
+                archive,
+                path,
+                out,
+                start,
+                len,
+                key_hex,
+                key_salt_hex,
+            } => {
+                let repo = repo_from_args(archive, key_hex, key_salt_hex)?;
+                let mut reader: Box<dyn Read + Send> = if let Some(l) = len {
+                    repo.open_range(&path, start, l)?
+                } else {
+                    repo.open_reader(&path)?
+                };
+                let mut file = std::fs::File::create(&out)?;
+                let mut buf = [0u8; 256 * 1024];
+                loop {
+                    let n = reader.read(&mut buf)?;
+                    if n == 0 {
+                        break;
+                    }
+                    file.write_all(&buf[..n])?;
+                }
+            }
+        },
     }
 
     Ok(())


### PR DESCRIPTION
- Introduced `domain.rs` to define `FileRow` and `ChunkRow` structs for file and chunk metadata representation.
- Created `repo.rs` to define the `OpenParams` struct and `ArchiveRepo` trait for repository operations.
- Implemented `repo_factory.rs` to facilitate repository opening based on backend type.
- Developed `repo_fs.rs` to provide a filesystem-based implementation of the `ArchiveRepo` trait, enabling file listing and chunk mapping.
- Added `opened.rs` and `stream.rs` for handling opened archives and streaming data, respectively, enhancing data access and manipulation capabilities.
- Updated `lib.rs` to include new modules, improving the overall structure and organization of the codebase.